### PR TITLE
Fixup Discord Invite Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project supports *macOS 10.15.4* or later.
 <br>
 
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/gcenx)
-[![](https://dcbadge.limes.pink/api/server/hD48GFpWz5?compact=true)](https://discord.gg/NTrT4QUvVS)
+[![](https://dcbadge.limes.pink/api/server/https://discord.gg/NTrT4QUvVS?compact=true)](https://discord.gg/NTrT4QUvVS)
 
 <br>
 


### PR DESCRIPTION
Seems the API changed a while ago & the old behavior was finally removed, causing the link to be invisible

On main, note the absence of an invite link:  
<img width="592" height="298" alt="image" src="https://github.com/user-attachments/assets/fbfe1b68-08a2-499d-bc7e-fcfdef755a7b" />

On my PR, note the presence of an invite link:  
<img width="592" height="298" alt="image" src="https://github.com/user-attachments/assets/ba52c962-4ed2-4ad7-a535-4811bf631351" />
